### PR TITLE
Align inference probabilities with measurement mapping

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -65,6 +65,9 @@ WEIGHT_QPY_PATH = "model/depth=16_ite=100_circuit.qpy"
 # File path for storing raw hardware measurement results
 HARDWARE_RAW_RESULT_PATH = f"{MODEL_DIR}/hardware_counts.json"
 
+# File path for storing raw simulator measurement results
+SIMULATOR_RAW_RESULT_PATH = f"{MODEL_DIR}/simulator_counts.json"
+
 # IBM Quantum runtime configuration
 # Set ``IBM_API_KEY`` to the API key associated with your IBM Quantum account.
 IBM_API_KEY = ""
@@ -76,3 +79,6 @@ IBM_CHANNEL = "ibm_cloud"
 IBM_BACKEND = "ibm_oslo"
 # Number of shots to collect when sampling circuits on hardware.
 IBM_SHOTS = 100
+
+# Number of shots to collect when sampling circuits on the simulator.
+SIMULATOR_SHOTS = 1000

--- a/src/hardware_inference_qpy.py
+++ b/src/hardware_inference_qpy.py
@@ -46,10 +46,9 @@ def load_trained_circuit(qpy_path: str):
 
 
 def _build_sampling_circuit(model: QclClassification, x_sample: np.ndarray):
-    """Encode a single sample and attach measurements for hardware execution."""
+    """Encode a pre-scaled sample and attach measurements for hardware execution."""
 
-    x_scaled = min_max_scaling(np.asarray([x_sample]))[0]
-    input_gate = model.create_input_gate(x_scaled)
+    input_gate = model.create_input_gate(x_sample)
 
     circuit = input_gate.compose(model.output_gate)
     circuit.measure_all()
@@ -90,6 +89,7 @@ def run_hardware_inference(sample_count: int = 5):
         raise ValueError("Set IBM_API_KEY in config.py before running hardware inference.")
 
     _, x_test, _, y_test = load_pt_features(TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM)
+    x_scaled = min_max_scaling(x_test)
     num_class = len(np.unique(y_test))
 
     circuit = load_trained_circuit(WEIGHT_QPY_PATH)
@@ -115,7 +115,7 @@ def run_hardware_inference(sample_count: int = 5):
     sampler = SamplerV2(mode=backend)
 
     for idx in range(min(sample_count, len(x_test))):
-        qc = _build_sampling_circuit(model, x_test[idx])
+        qc = _build_sampling_circuit(model, x_scaled[idx])
 
         # ★ ISA に合わせて変換してから投げる
         isa_qc = pm.run(qc)

--- a/src/hardware_inference_qpy.py
+++ b/src/hardware_inference_qpy.py
@@ -154,7 +154,10 @@ def run_hardware_inference(sample_count: int = 5):
         json.dump(raw_results, f, ensure_ascii=False, indent=2)
     print(f"Raw hardware data saved to {HARDWARE_RAW_RESULT_PATH}")
 
-    return predictions
+    accuracy = float(np.mean(np.array(predictions) == y_test[: len(predictions)]))
+    print(f"Hardware sampling accuracy: {accuracy:.3f} ({len(predictions)} samples)")
+
+    return predictions, accuracy
 
 
 if __name__ == "__main__":

--- a/src/inference_qpy.py
+++ b/src/inference_qpy.py
@@ -3,38 +3,17 @@
 This utility loads a trained quantum circuit serialized in QPY format and
 evaluates it on the test split. The script mirrors the preprocessing used in
 training so the feature scaling is consistent.
-
-In addition to the amplitude-based inference used for accuracy evaluation, the
-script can also run sampling on a local simulator to produce hardware-like
-measurement counts and save them for inspection.
 """
 
 from __future__ import annotations
 
-import argparse
-import json
-import os
-from typing import Dict, List
-
 import numpy as np
-from qiskit import qpy, transpile
-from qiskit.quantum_info import Statevector
-from qiskit_aer import AerSimulator
 from sklearn.metrics import accuracy_score
+from qiskit import qpy
 
-from config import (
-    C_DEPTH,
-    NQUBIT,
-    PCA_DIM,
-    SIMULATOR_RAW_RESULT_PATH,
-    SIMULATOR_SHOTS,
-    TEST_DATA_PATH,
-    TRAIN_DATA_PATH,
-    WEIGHT_QPY_PATH,
-)
+from config import C_DEPTH, NQUBIT, PCA_DIM, TEST_DATA_PATH, TRAIN_DATA_PATH, WEIGHT_QPY_PATH
 from data_utils import load_pt_features
 from qcl_classification import QclClassification
-from qcl_utils import min_max_scaling
 
 
 def load_trained_circuit(qpy_path: str):
@@ -53,46 +32,8 @@ def load_trained_circuit(qpy_path: str):
     return circuits[0]
 
 
-def _build_sampling_circuit(model: QclClassification, x_sample: np.ndarray):
-    """Encode a single sample and attach measurements for simulator execution."""
-
-    x_scaled = min_max_scaling(np.asarray([x_sample]))[0]
-    input_gate = model.create_input_gate(x_scaled)
-
-    circuit = input_gate.compose(model.output_gate)
-    circuit.measure_all()
-    return circuit
-
-
-def _counts_to_probs(counts: Dict[str, int], num_class: int) -> np.ndarray:
-    """Convert sampled bitstring counts into class probabilities.
-
-    Each computational-basis bitstring is treated as the integer label for the
-    corresponding class. The probability for class ``k`` is the fraction of
-    shots whose bitstring decodes to ``k``.
-    """
-
-    shots = sum(counts.values()) if counts else 1
-    quasi = {int(bitstr, 2): c / shots for bitstr, c in counts.items()}
-    return np.array([quasi.get(cls, 0.0) for cls in range(num_class)])
-
-
-def _state_to_probs(state: Statevector, num_class: int) -> np.ndarray:
-    """Convert a ``Statevector`` to class probabilities.
-
-    This mirrors the measurement-count postprocessing by using the probability
-    of each computational-basis state (without sampling noise) as the class
-    likelihood. It keeps the mapping where the measured bitstring encodes the
-    class index.
-    """
-
-    full_probs = state.probabilities()
-    probs = np.array([full_probs[cls] if cls < len(full_probs) else 0.0 for cls in range(num_class)])
-    return probs / probs.sum() if probs.sum() > 0 else probs
-
-
 def run_inference():
-    """Load the trained circuit and report test accuracy using amplitudes."""
+    """Load the trained circuit and report test accuracy."""
 
     _, x_test, _, y_test = load_pt_features(
         TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM
@@ -104,13 +45,7 @@ def run_inference():
     model = QclClassification(NQUBIT, C_DEPTH, num_class)
     model.set_output_gate(circuit)
 
-    preds = []
-    for x in min_max_scaling(x_test):
-        state = model._state_for_x(x, model.theta)
-        probs = _state_to_probs(state, num_class)
-        preds.append(probs)
-
-    preds = np.array(preds)
+    preds = model.pred_amplitude(x_test)
     pred_labels = np.argmax(preds, axis=1)
     acc = accuracy_score(y_test, pred_labels)
 
@@ -118,87 +53,6 @@ def run_inference():
     return acc
 
 
-def run_sampling_inference(sample_count: int = 5) -> List[int]:
-    """Execute the trained circuit on AerSimulator and store raw counts."""
-
-    _, x_test, _, y_test = load_pt_features(TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM)
-    num_class = len(np.unique(y_test))
-
-    circuit = load_trained_circuit(WEIGHT_QPY_PATH)
-    model = QclClassification(NQUBIT, C_DEPTH, num_class)
-    model.set_output_gate(circuit)
-
-    simulator = AerSimulator()
-
-    predictions: List[int] = []
-    raw_results = []
-
-    for idx in range(min(sample_count, len(x_test))):
-        qc = _build_sampling_circuit(model, x_test[idx])
-        compiled = transpile(qc, simulator)
-        job = simulator.run(compiled, shots=SIMULATOR_SHOTS)
-        res = job.result()
-        counts = res.get_counts(0)
-
-        probs = _counts_to_probs(counts, num_class)
-        pred_label = int(np.argmax(probs))
-
-        predictions.append(pred_label)
-        raw_results.append(
-            {
-                "sample_index": idx,
-                "counts": counts,
-                "shots": sum(counts.values()) if counts else 0,
-                "probabilities": probs.tolist(),
-                "predicted_label": pred_label,
-                "true_label": int(y_test[idx]),
-            }
-        )
-        print(
-            f"sample {idx}: predicted={pred_label}, true={int(y_test[idx])}, distribution={probs}"
-        )
-
-    os.makedirs(os.path.dirname(SIMULATOR_RAW_RESULT_PATH) or ".", exist_ok=True)
-    with open(SIMULATOR_RAW_RESULT_PATH, "w", encoding="utf-8") as f:
-        json.dump(raw_results, f, ensure_ascii=False, indent=2)
-    print(
-        f"Raw simulator data saved to {SIMULATOR_RAW_RESULT_PATH} (shots={SIMULATOR_SHOTS})."
-    )
-
-    return predictions
-
-
-def _build_arg_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run QPY inference.")
-    parser.add_argument(
-        "--mode",
-        choices=["amplitude", "sampling"],
-        default="amplitude",
-        help="Inference mode: amplitude-based accuracy or sampling counts on AerSimulator.",
-    )
-    parser.add_argument(
-        "--samples",
-        type=int,
-        default=5,
-        help="Number of test samples to evaluate when using sampling mode.",
-    )
-    return parser
-
-
-def main():
-    parser = _build_arg_parser()
-    args = parser.parse_args()
-
-    print(f"Loading trained circuit from {WEIGHT_QPY_PATH}")
-
-    if args.mode == "sampling":
-        print(
-            f"Starting simulator inference with {SIMULATOR_SHOTS} shots per circuit (samples={args.samples})."
-        )
-        run_sampling_inference(sample_count=args.samples)
-    else:
-        run_inference()
-
-
 if __name__ == "__main__":
-    main()
+    print(f"Loading trained circuit from {WEIGHT_QPY_PATH}")
+    run_inference()

--- a/src/inference_qpy.py
+++ b/src/inference_qpy.py
@@ -3,17 +3,38 @@
 This utility loads a trained quantum circuit serialized in QPY format and
 evaluates it on the test split. The script mirrors the preprocessing used in
 training so the feature scaling is consistent.
+
+In addition to the amplitude-based inference used for accuracy evaluation, the
+script can also run sampling on a local simulator to produce hardware-like
+measurement counts and save them for inspection.
 """
 
 from __future__ import annotations
 
-import numpy as np
-from sklearn.metrics import accuracy_score
-from qiskit import qpy
+import argparse
+import json
+import os
+from typing import Dict, List
 
-from config import C_DEPTH, NQUBIT, PCA_DIM, TEST_DATA_PATH, TRAIN_DATA_PATH, WEIGHT_QPY_PATH
+import numpy as np
+from qiskit import qpy, transpile
+from qiskit.quantum_info import Statevector
+from qiskit_aer import AerSimulator
+from sklearn.metrics import accuracy_score
+
+from config import (
+    C_DEPTH,
+    NQUBIT,
+    PCA_DIM,
+    SIMULATOR_RAW_RESULT_PATH,
+    SIMULATOR_SHOTS,
+    TEST_DATA_PATH,
+    TRAIN_DATA_PATH,
+    WEIGHT_QPY_PATH,
+)
 from data_utils import load_pt_features
 from qcl_classification import QclClassification
+from qcl_utils import min_max_scaling
 
 
 def load_trained_circuit(qpy_path: str):
@@ -32,8 +53,46 @@ def load_trained_circuit(qpy_path: str):
     return circuits[0]
 
 
+def _build_sampling_circuit(model: QclClassification, x_sample: np.ndarray):
+    """Encode a single sample and attach measurements for simulator execution."""
+
+    x_scaled = min_max_scaling(np.asarray([x_sample]))[0]
+    input_gate = model.create_input_gate(x_scaled)
+
+    circuit = input_gate.compose(model.output_gate)
+    circuit.measure_all()
+    return circuit
+
+
+def _counts_to_probs(counts: Dict[str, int], num_class: int) -> np.ndarray:
+    """Convert sampled bitstring counts into class probabilities.
+
+    Each computational-basis bitstring is treated as the integer label for the
+    corresponding class. The probability for class ``k`` is the fraction of
+    shots whose bitstring decodes to ``k``.
+    """
+
+    shots = sum(counts.values()) if counts else 1
+    quasi = {int(bitstr, 2): c / shots for bitstr, c in counts.items()}
+    return np.array([quasi.get(cls, 0.0) for cls in range(num_class)])
+
+
+def _state_to_probs(state: Statevector, num_class: int) -> np.ndarray:
+    """Convert a ``Statevector`` to class probabilities.
+
+    This mirrors the measurement-count postprocessing by using the probability
+    of each computational-basis state (without sampling noise) as the class
+    likelihood. It keeps the mapping where the measured bitstring encodes the
+    class index.
+    """
+
+    full_probs = state.probabilities()
+    probs = np.array([full_probs[cls] if cls < len(full_probs) else 0.0 for cls in range(num_class)])
+    return probs / probs.sum() if probs.sum() > 0 else probs
+
+
 def run_inference():
-    """Load the trained circuit and report test accuracy."""
+    """Load the trained circuit and report test accuracy using amplitudes."""
 
     _, x_test, _, y_test = load_pt_features(
         TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM
@@ -45,7 +104,13 @@ def run_inference():
     model = QclClassification(NQUBIT, C_DEPTH, num_class)
     model.set_output_gate(circuit)
 
-    preds = model.pred_amplitude(x_test)
+    preds = []
+    for x in min_max_scaling(x_test):
+        state = model._state_for_x(x, model.theta)
+        probs = _state_to_probs(state, num_class)
+        preds.append(probs)
+
+    preds = np.array(preds)
     pred_labels = np.argmax(preds, axis=1)
     acc = accuracy_score(y_test, pred_labels)
 
@@ -53,6 +118,87 @@ def run_inference():
     return acc
 
 
-if __name__ == "__main__":
+def run_sampling_inference(sample_count: int = 5) -> List[int]:
+    """Execute the trained circuit on AerSimulator and store raw counts."""
+
+    _, x_test, _, y_test = load_pt_features(TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM)
+    num_class = len(np.unique(y_test))
+
+    circuit = load_trained_circuit(WEIGHT_QPY_PATH)
+    model = QclClassification(NQUBIT, C_DEPTH, num_class)
+    model.set_output_gate(circuit)
+
+    simulator = AerSimulator()
+
+    predictions: List[int] = []
+    raw_results = []
+
+    for idx in range(min(sample_count, len(x_test))):
+        qc = _build_sampling_circuit(model, x_test[idx])
+        compiled = transpile(qc, simulator)
+        job = simulator.run(compiled, shots=SIMULATOR_SHOTS)
+        res = job.result()
+        counts = res.get_counts(0)
+
+        probs = _counts_to_probs(counts, num_class)
+        pred_label = int(np.argmax(probs))
+
+        predictions.append(pred_label)
+        raw_results.append(
+            {
+                "sample_index": idx,
+                "counts": counts,
+                "shots": sum(counts.values()) if counts else 0,
+                "probabilities": probs.tolist(),
+                "predicted_label": pred_label,
+                "true_label": int(y_test[idx]),
+            }
+        )
+        print(
+            f"sample {idx}: predicted={pred_label}, true={int(y_test[idx])}, distribution={probs}"
+        )
+
+    os.makedirs(os.path.dirname(SIMULATOR_RAW_RESULT_PATH) or ".", exist_ok=True)
+    with open(SIMULATOR_RAW_RESULT_PATH, "w", encoding="utf-8") as f:
+        json.dump(raw_results, f, ensure_ascii=False, indent=2)
+    print(
+        f"Raw simulator data saved to {SIMULATOR_RAW_RESULT_PATH} (shots={SIMULATOR_SHOTS})."
+    )
+
+    return predictions
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run QPY inference.")
+    parser.add_argument(
+        "--mode",
+        choices=["amplitude", "sampling"],
+        default="amplitude",
+        help="Inference mode: amplitude-based accuracy or sampling counts on AerSimulator.",
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=5,
+        help="Number of test samples to evaluate when using sampling mode.",
+    )
+    return parser
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
     print(f"Loading trained circuit from {WEIGHT_QPY_PATH}")
-    run_inference()
+
+    if args.mode == "sampling":
+        print(
+            f"Starting simulator inference with {SIMULATOR_SHOTS} shots per circuit (samples={args.samples})."
+        )
+        run_sampling_inference(sample_count=args.samples)
+    else:
+        run_inference()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shot_inference.py
+++ b/src/shot_inference.py
@@ -1,0 +1,153 @@
+"""Shot-based inference on a local simulator.
+
+This script runs the trained QPY circuit on ``AerSimulator`` with a specified
+number of shots, collects raw measurement counts, converts them to class
+probabilities, and saves the results to disk. It mirrors the bitstring-to-class
+mapping used by hardware inference, keeping sampling separate from the
+amplitude-based accuracy evaluation in ``inference_qpy.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Dict, List
+
+import numpy as np
+from qiskit import qpy, transpile
+from qiskit_aer import AerSimulator
+
+from config import (
+    C_DEPTH,
+    NQUBIT,
+    PCA_DIM,
+    SIMULATOR_RAW_RESULT_PATH,
+    SIMULATOR_SHOTS,
+    TEST_DATA_PATH,
+    TRAIN_DATA_PATH,
+    WEIGHT_QPY_PATH,
+)
+from data_utils import load_pt_features
+from qcl_classification import QclClassification
+from qcl_utils import min_max_scaling
+
+
+def load_trained_circuit(qpy_path: str):
+    """Load a single trained circuit from a QPY file."""
+
+    with open(qpy_path, "rb") as f:
+        circuits = qpy.load(f)
+
+    if not circuits:
+        raise ValueError(f"No circuits found in QPY file: {qpy_path}")
+    if len(circuits) > 1:
+        print(
+            f"[warning] Multiple circuits found in {qpy_path}; using the first entry for inference."
+        )
+
+    return circuits[0]
+
+
+def _build_sampling_circuit(model: QclClassification, x_sample: np.ndarray):
+    """Encode a single sample and attach measurements for simulator execution."""
+
+    x_scaled = min_max_scaling(np.asarray([x_sample]))[0]
+    input_gate = model.create_input_gate(x_scaled)
+
+    circuit = input_gate.compose(model.output_gate)
+    circuit.measure_all()
+    return circuit
+
+
+def _counts_to_probs(counts: Dict[str, int], num_class: int) -> np.ndarray:
+    """Convert sampled bitstring counts into class probabilities.
+
+    Each computational-basis bitstring is treated as the integer label for the
+    corresponding class. The probability for class ``k`` is the fraction of
+    shots whose bitstring decodes to ``k``.
+    """
+
+    shots = sum(counts.values()) if counts else 1
+    quasi = {int(bitstr, 2): c / shots for bitstr, c in counts.items()}
+    return np.array([quasi.get(cls, 0.0) for cls in range(num_class)])
+
+
+def run_shot_inference(sample_count: int = 5, shots: int = SIMULATOR_SHOTS) -> List[int]:
+    """Execute the trained circuit on AerSimulator and store raw counts."""
+
+    _, x_test, _, y_test = load_pt_features(TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM)
+    num_class = len(np.unique(y_test))
+
+    circuit = load_trained_circuit(WEIGHT_QPY_PATH)
+    model = QclClassification(NQUBIT, C_DEPTH, num_class)
+    model.set_output_gate(circuit)
+
+    simulator = AerSimulator()
+
+    predictions: List[int] = []
+    raw_results = []
+
+    for idx in range(min(sample_count, len(x_test))):
+        qc = _build_sampling_circuit(model, x_test[idx])
+        compiled = transpile(qc, simulator)
+        job = simulator.run(compiled, shots=shots)
+        res = job.result()
+        counts = res.get_counts(0)
+
+        probs = _counts_to_probs(counts, num_class)
+        pred_label = int(np.argmax(probs))
+
+        predictions.append(pred_label)
+        raw_results.append(
+            {
+                "sample_index": idx,
+                "counts": counts,
+                "shots": sum(counts.values()) if counts else 0,
+                "probabilities": probs.tolist(),
+                "predicted_label": pred_label,
+                "true_label": int(y_test[idx]),
+            }
+        )
+        print(
+            f"sample {idx}: predicted={pred_label}, true={int(y_test[idx])}, distribution={probs}"
+        )
+
+    os.makedirs(os.path.dirname(SIMULATOR_RAW_RESULT_PATH) or ".", exist_ok=True)
+    with open(SIMULATOR_RAW_RESULT_PATH, "w", encoding="utf-8") as f:
+        json.dump(raw_results, f, ensure_ascii=False, indent=2)
+    print(f"Raw simulator data saved to {SIMULATOR_RAW_RESULT_PATH} (shots={shots}).")
+
+    return predictions
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run shot-based inference on AerSimulator.")
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=5,
+        help="Number of test samples to evaluate with shot-based inference.",
+    )
+    parser.add_argument(
+        "--shots",
+        type=int,
+        default=SIMULATOR_SHOTS,
+        help="Number of shots to execute per circuit.",
+    )
+    return parser
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    print(f"Loading trained circuit from {WEIGHT_QPY_PATH}")
+    print(
+        f"Starting shot-based simulator inference with {args.shots} shots per circuit (samples={args.samples})."
+    )
+    run_shot_inference(sample_count=args.samples, shots=args.shots)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shot_inference.py
+++ b/src/shot_inference.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import numpy as np
 from qiskit import qpy, transpile
@@ -80,8 +80,14 @@ def _counts_to_probs(counts: Dict[str, int], num_class: int) -> np.ndarray:
     return class_counts / shots
 
 
-def run_shot_inference(shots: int = SIMULATOR_SHOTS) -> List[int]:
-    """Execute the trained circuit on AerSimulator for every test sample."""
+def run_shot_inference(shots: int = SIMULATOR_SHOTS) -> Tuple[List[int], float]:
+    """Execute the trained circuit on AerSimulator for every test sample.
+
+    Returns
+    -------
+    Tuple[List[int], float]
+        Predicted labels for each test sample and the overall accuracy.
+    """
 
     _, x_test, _, y_test = load_pt_features(TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM)
     x_scaled = min_max_scaling(x_test)
@@ -126,7 +132,10 @@ def run_shot_inference(shots: int = SIMULATOR_SHOTS) -> List[int]:
         json.dump(raw_results, f, ensure_ascii=False, indent=2)
     print(f"Raw simulator data saved to {SIMULATOR_RAW_RESULT_PATH} (shots={shots}).")
 
-    return predictions
+    accuracy = float(np.mean(np.array(predictions) == y_test))
+    print(f"Simulator sampling accuracy: {accuracy:.3f} ({len(predictions)} samples)")
+
+    return predictions, accuracy
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:

--- a/src/shot_inference.py
+++ b/src/shot_inference.py
@@ -50,10 +50,9 @@ def load_trained_circuit(qpy_path: str):
 
 
 def _build_sampling_circuit(model: QclClassification, x_sample: np.ndarray):
-    """Encode a single sample and attach measurements for simulator execution."""
+    """Encode a pre-scaled sample and attach measurements for simulator execution."""
 
-    x_scaled = min_max_scaling(np.asarray([x_sample]))[0]
-    input_gate = model.create_input_gate(x_scaled)
+    input_gate = model.create_input_gate(x_sample)
 
     circuit = input_gate.compose(model.output_gate)
     circuit.measure_all()
@@ -85,6 +84,7 @@ def run_shot_inference(shots: int = SIMULATOR_SHOTS) -> List[int]:
     """Execute the trained circuit on AerSimulator for every test sample."""
 
     _, x_test, _, y_test = load_pt_features(TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM)
+    x_scaled = min_max_scaling(x_test)
     num_class = len(np.unique(y_test))
 
     circuit = load_trained_circuit(WEIGHT_QPY_PATH)
@@ -96,7 +96,7 @@ def run_shot_inference(shots: int = SIMULATOR_SHOTS) -> List[int]:
     predictions: List[int] = []
     raw_results = []
 
-    for idx, x_sample in enumerate(x_test):
+    for idx, x_sample in enumerate(x_scaled):
         qc = _build_sampling_circuit(model, x_sample)
         compiled = transpile(qc, simulator)
         job = simulator.run(compiled, shots=shots)

--- a/src/shot_inference.py
+++ b/src/shot_inference.py
@@ -73,8 +73,8 @@ def _counts_to_probs(counts: Dict[str, int], num_class: int) -> np.ndarray:
     return np.array([quasi.get(cls, 0.0) for cls in range(num_class)])
 
 
-def run_shot_inference(sample_count: int = 5, shots: int = SIMULATOR_SHOTS) -> List[int]:
-    """Execute the trained circuit on AerSimulator and store raw counts."""
+def run_shot_inference(shots: int = SIMULATOR_SHOTS) -> List[int]:
+    """Execute the trained circuit on AerSimulator for every test sample."""
 
     _, x_test, _, y_test = load_pt_features(TRAIN_DATA_PATH, TEST_DATA_PATH, PCA_DIM)
     num_class = len(np.unique(y_test))
@@ -88,8 +88,8 @@ def run_shot_inference(sample_count: int = 5, shots: int = SIMULATOR_SHOTS) -> L
     predictions: List[int] = []
     raw_results = []
 
-    for idx in range(min(sample_count, len(x_test))):
-        qc = _build_sampling_circuit(model, x_test[idx])
+    for idx, x_sample in enumerate(x_test):
+        qc = _build_sampling_circuit(model, x_sample)
         compiled = transpile(qc, simulator)
         job = simulator.run(compiled, shots=shots)
         res = job.result()
@@ -124,12 +124,6 @@ def run_shot_inference(sample_count: int = 5, shots: int = SIMULATOR_SHOTS) -> L
 def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run shot-based inference on AerSimulator.")
     parser.add_argument(
-        "--samples",
-        type=int,
-        default=5,
-        help="Number of test samples to evaluate with shot-based inference.",
-    )
-    parser.add_argument(
         "--shots",
         type=int,
         default=SIMULATOR_SHOTS,
@@ -144,9 +138,9 @@ def main():
 
     print(f"Loading trained circuit from {WEIGHT_QPY_PATH}")
     print(
-        f"Starting shot-based simulator inference with {args.shots} shots per circuit (samples={args.samples})."
+        f"Starting shot-based simulator inference with {args.shots} shots per circuit for all test samples."
     )
-    run_shot_inference(sample_count=args.samples, shots=args.shots)
+    run_shot_inference(shots=args.shots)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- align amplitude-based inference with the measurement-based class mapping by deriving class probabilities from computational-basis probabilities
- document the sampling-to-class decoding so bitstrings map directly to class indices

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6942358db59083308dd44d3e87e4661f)